### PR TITLE
Fix interface conversion when Kind() == string but v.(string) panics

### DIFF
--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -152,6 +152,25 @@ func TestNilField(t *testing.T) {
 	assert.Equal(t, logrus.Fields{"Nil": nil}, logEntry.Data)
 }
 
+type stringerValue struct {
+	value string
+}
+
+func (v stringerValue) String() string {
+	return v.value
+}
+
+func TestStringer(t *testing.T) {
+	logEntry := &logrus.Entry{
+		Data: logrus.Fields{"Stringer": stringerValue{"kind is io.Stringer"}},
+	}
+	h = &Hook{RedactionList: []string{"kind"}}
+	err := h.Fire(logEntry)
+
+	assert.Nil(t, err)
+	assert.Equal(t, logrus.Fields{"Stringer": "[REDACTED] is io.Stringer"}, logEntry.Data)
+}
+
 type TypedString string
 
 // Logrus fields can have re-typed strings so test we handle this edge case

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -159,9 +159,9 @@ func TestTypedStringValue(t *testing.T) {
 	logEntry := &logrus.Entry{
 		Data: logrus.Fields{"TypedString": TypedString("kind is string")},
 	}
-	h = &Hook{RedactionList: []string{"foo"}}
+	h = &Hook{RedactionList: []string{"kind"}}
 	err := h.Fire(logEntry)
 
 	assert.Nil(t, err)
-	assert.Equal(t, logrus.Fields{"TypedString": "kind is string"}, logEntry.Data)
+	assert.Equal(t, logrus.Fields{"TypedString": "[REDACTED] is string"}, logEntry.Data)
 }

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -151,3 +151,17 @@ func TestNilField(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, logrus.Fields{"Nil": nil}, logEntry.Data)
 }
+
+type TypedString string
+
+// Logrus fields can have re-typed strings so test we handle this edge case
+func TestTypedStringValue(t *testing.T) {
+	logEntry := &logrus.Entry{
+		Data: logrus.Fields{"TypedString": TypedString("kind is string")},
+	}
+	h = &Hook{RedactionList: []string{"foo"}}
+	err := h.Fire(logEntry)
+
+	assert.Nil(t, err)
+	assert.Equal(t, logrus.Fields{"TypedString": "kind is string"}, logEntry.Data)
+}

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -162,13 +162,13 @@ func (v stringerValue) String() string {
 
 func TestStringer(t *testing.T) {
 	logEntry := &logrus.Entry{
-		Data: logrus.Fields{"Stringer": stringerValue{"kind is io.Stringer"}},
+		Data: logrus.Fields{"Stringer": stringerValue{"kind is fmt.Stringer"}},
 	}
 	h = &Hook{RedactionList: []string{"kind"}}
 	err := h.Fire(logEntry)
 
 	assert.Nil(t, err)
-	assert.Equal(t, logrus.Fields{"Stringer": "[REDACTED] is io.Stringer"}, logEntry.Data)
+	assert.Equal(t, logrus.Fields{"Stringer": "[REDACTED] is fmt.Stringer"}, logEntry.Data)
 }
 
 type TypedString string


### PR DESCRIPTION
Added a type switch in the type cast to handle the case when the Kind == string but type casting to string will panic because it's a typed string value.