### PR TITLE
Handle fmt.Stringer types that are passed as nil pointers

### DIFF
--- a/redactrus.go
+++ b/redactrus.go
@@ -52,7 +52,8 @@ func (h *Hook) Fire(e *logrus.Entry) error {
 			}
 
 			// Logrus Field values can be nil
-			if v == nil {
+			if v == nil || reflect.ValueOf(v).IsNil() {
+				fmt.Println("is nil")
 				continue
 			}
 

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -2,6 +2,7 @@ package redactrus
 
 import (
 	"testing"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -180,11 +180,9 @@ func (s S) String() string {
 }
 
 func TestNilPointerWithValReceiver(t *testing.T) {
-	// TODO: need to add a test case with nil + non-nil values on the same
-	// struct type to catch why .IsNil() doesn't work
-	var tp *S
+	var s *S
 	logEntry := &logrus.Entry{
-		Data: logrus.Fields{"NilTime": tp},
+		Data: logrus.Fields{"nil-stringer": s},
 	}
 	h = &Hook{RedactionList: []string{"foo"}}
 	err := h.Fire(logEntry)

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -171,6 +171,25 @@ func TestStringer(t *testing.T) {
 	assert.Equal(t, logrus.Fields{"Stringer": "[REDACTED] is fmt.Stringer"}, logEntry.Data)
 }
 
+type S struct {
+	v string
+}
+
+func (s S) String() string {
+	return s.v
+}
+
+func TestNilPointer(t *testing.T) {
+	var tp *S
+	logEntry := &logrus.Entry{
+		Data: logrus.Fields{"NilTime": tp},
+	}
+	h = &Hook{RedactionList: []string{"foo"}}
+	err := h.Fire(logEntry)
+
+	assert.Nil(t, err)
+}
+
 type TypedString string
 
 // Logrus fields can have re-typed strings so test we handle this edge case

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -175,7 +175,13 @@ func TestStringer(t *testing.T) {
 		Data: logrus.Fields{"Stringer": s},
 	}
 	err = h.Fire(nilStringerEntry)
-
+	assert.Nil(t, err)
+ 
+	var stringer fmt.Stringer
+	nilStringerEntry = &logrus.Entry{
+		Data: logrus.Fields{"Stringer": stringer},
+	}
+	err = h.Fire(nilStringerEntry)
 	assert.Nil(t, err)
 }
 

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -169,23 +169,12 @@ func TestStringer(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, logrus.Fields{"Stringer": "[REDACTED] is fmt.Stringer"}, logEntry.Data)
-}
 
-type S struct {
-	v string
-}
-
-func (s S) String() string {
-	return s.v
-}
-
-func TestNilPointerWithValReceiver(t *testing.T) {
-	var s *S
-	logEntry := &logrus.Entry{
-		Data: logrus.Fields{"nil-stringer": s},
+	var s *stringerValue
+	nilStringerEntry := &logrus.Entry{
+		Data: logrus.Fields{"Stringer": s},
 	}
-	h = &Hook{RedactionList: []string{"foo"}}
-	err := h.Fire(logEntry)
+	err = h.Fire(nilStringerEntry)
 
 	assert.Nil(t, err)
 }

--- a/redactrus_test.go
+++ b/redactrus_test.go
@@ -179,7 +179,9 @@ func (s S) String() string {
 	return s.v
 }
 
-func TestNilPointer(t *testing.T) {
+func TestNilPointerWithValReceiver(t *testing.T) {
+	// TODO: need to add a test case with nil + non-nil values on the same
+	// struct type to catch why .IsNil() doesn't work
 	var tp *S
 	logEntry := &logrus.Entry{
 		Data: logrus.Fields{"NilTime": tp},


### PR DESCRIPTION
Discovered this when passing a `*time.Time` field value that was nil. `fmt.Stringer` types would cause panics if passed as nil pointers.